### PR TITLE
Support swagger-template.json file when generate swagger.json

### DIFF
--- a/bin/apidocSwagger.js
+++ b/bin/apidocSwagger.js
@@ -72,6 +72,8 @@ var argv = nomnom
     .option('marked-smartypants', { flag: true, 'default': false,
             help: 'Use \'smart\' typograhic punctuation for things like quotes and dashes.' })
 
+    .option('template', { abbr: 't', 'default': './', help: 'Template file dirname' })
+
     .parse()
 ;
 
@@ -137,7 +139,8 @@ var options = {
     silent        : argv['silent'],
     simulate      : argv['simulate'],
     markdown      : argv['markdown'],
-    marked        : resolveMarkdownOptions(argv)
+    marked        : resolveMarkdownOptions(argv),
+    template      : argv['template']
 };
 
 if (apidocSwagger.createApidocSwagger(options) === false) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -128,8 +128,16 @@ function createOutputFile(api){
 
     //Write swagger
     app.log.verbose('write swagger json file: ' + app.options.dest + 'swagger.json');
-    if( ! app.options.simulate)
-        fs.writeFileSync(app.options.dest + './swagger.json', api.swaggerData); 
+    if( ! app.options.simulate) {
+        var templateName = path.resolve(app.options.template, 'swagger-template.json');
+        if (fs.existsSync(templateName)) {
+            app.log.verbose('read swagger template file: ' + templateName);
+            var templateData = JSON.parse(fs.readFileSync(templateName, 'utf8'));
+            api.swaggerData = JSON.stringify(_.defaults(JSON.parse(api.swaggerData), templateData));
+        }
+
+        fs.writeFileSync(app.options.dest + './swagger.json', api.swaggerData);
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
- To enable auth in the python client API code for API 1.1, below fields need to be added in swagger.json according to http://swagger.io/specification/#securityDefinitionsObject

```
{
    "securityDefinitions": {
        "auth_token": {
            "type": "apiKey",
            "name": "authorization",
            "in": "header"
        }
    },
    "security": [
        {
        "auth_token": []
        }
    ]
}
```
- With creating a swagger-template.json, we could customize fields in the swagger.json.

@jlongever @RackHD/corecommitters

Note: another PR in on-http to add swagger-template.json
